### PR TITLE
fix: support un-chunked and raw JSON cookie formats

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -134,8 +134,14 @@ export class MobbinAuth {
   private static parseSessionFromCookie(cookie: string): SupabaseSession {
     // Try parsing as raw JSON first (handles direct session JSON input)
     try {
-      const parsed = JSON.parse(cookie);
-      if (parsed.access_token && parsed.refresh_token) {
+      const parsed = JSON.parse(cookie) as Partial<SupabaseSession> | null;
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        typeof parsed.access_token === "string" &&
+        typeof parsed.refresh_token === "string" &&
+        typeof parsed.expires_at === "number"
+      ) {
         return parsed as SupabaseSession;
       }
     } catch {
@@ -150,28 +156,29 @@ export class MobbinAuth {
       return acc;
     }, {});
 
-    // Try chunked format first (.0 and .1 suffixes)
     const chunk0 = cookies[`${SUPABASE_COOKIE_PREFIX}.0`] ?? "";
     const chunk1 = cookies[`${SUPABASE_COOKIE_PREFIX}.1`] ?? "";
-
-    // Fall back to un-chunked single cookie
     const unchunked = cookies[SUPABASE_COOKIE_PREFIX] ?? "";
 
-    const combined = chunk0 || chunk1
-      ? decodeURIComponent(chunk0 + chunk1)
-      : unchunked
-        ? decodeURIComponent(unchunked)
-        : "";
+    // Try all candidate formats — chunked first, then un-chunked
+    const candidates = [
+      ...(chunk0 || chunk1 ? [chunk0 + chunk1] : []),
+      ...(unchunked ? [unchunked] : []),
+    ];
 
-    try {
-      return JSON.parse(combined) as SupabaseSession;
-    } catch {
-      throw new Error(
-        `Failed to parse Supabase session from cookie. ` +
-          `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies, ` +
-          `or the un-chunked '${SUPABASE_COOKIE_PREFIX}' cookie.`,
-      );
+    for (const candidate of candidates) {
+      try {
+        return JSON.parse(decodeURIComponent(candidate)) as SupabaseSession;
+      } catch {
+        // try next candidate
+      }
     }
+
+    throw new Error(
+      `Failed to parse Supabase session from cookie. ` +
+        `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies, ` +
+        `or the un-chunked '${SUPABASE_COOKIE_PREFIX}' cookie.`,
+    );
   }
 
   /**

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -125,9 +125,23 @@ export class MobbinAuth {
 
   /**
    * Parse the Supabase session JSON from the raw cookie string.
-   * The session is split across two cookies (`.0` and `.1`) and URL-encoded.
+   *
+   * Supports three cookie formats:
+   * 1. Chunked: `sb-...-auth-token.0=<part1>; sb-...-auth-token.1=<part2>` (Supabase SSR default)
+   * 2. Single (un-chunked): `sb-...-auth-token=<url-encoded-json>` (older Supabase clients)
+   * 3. Raw JSON: direct `{"access_token": "..."}` string (e.g. from `document.cookie` copy)
    */
   private static parseSessionFromCookie(cookie: string): SupabaseSession {
+    // Try parsing as raw JSON first (handles direct session JSON input)
+    try {
+      const parsed = JSON.parse(cookie);
+      if (parsed.access_token && parsed.refresh_token) {
+        return parsed as SupabaseSession;
+      }
+    } catch {
+      // Not raw JSON, continue with cookie parsing
+    }
+
     const cookies = cookie.split("; ").reduce<Record<string, string>>((acc, part) => {
       const eqIdx = part.indexOf("=");
       if (eqIdx > 0) {
@@ -136,16 +150,26 @@ export class MobbinAuth {
       return acc;
     }, {});
 
+    // Try chunked format first (.0 and .1 suffixes)
     const chunk0 = cookies[`${SUPABASE_COOKIE_PREFIX}.0`] ?? "";
     const chunk1 = cookies[`${SUPABASE_COOKIE_PREFIX}.1`] ?? "";
-    const combined = decodeURIComponent(chunk0 + chunk1);
+
+    // Fall back to un-chunked single cookie
+    const unchunked = cookies[SUPABASE_COOKIE_PREFIX] ?? "";
+
+    const combined = chunk0 || chunk1
+      ? decodeURIComponent(chunk0 + chunk1)
+      : unchunked
+        ? decodeURIComponent(unchunked)
+        : "";
 
     try {
       return JSON.parse(combined) as SupabaseSession;
     } catch {
       throw new Error(
         `Failed to parse Supabase session from cookie. ` +
-          `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies.`,
+          `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies, ` +
+          `or the un-chunked '${SUPABASE_COOKIE_PREFIX}' cookie.`,
       );
     }
   }


### PR DESCRIPTION
## Summary

- `parseSessionFromCookie` now supports three cookie formats instead of just the chunked `.0`/`.1` format:
  1. **Chunked** (`.0`/`.1` suffixes) — Supabase SSR default, existing behavior preserved
  2. **Single un-chunked** (`sb-...-auth-token=<value>`) — used by older Supabase clients and some browser configurations
  3. **Raw JSON** — direct `{"access_token": "..."}` input

- Improves the error message to mention the un-chunked format as an alternative

## Problem

When users copy cookies from browsers that store the Supabase session as a single un-chunked `sb-ujasntkfphywizsdaapi-auth-token` cookie (rather than chunked into `.0` and `.1`), the parser silently gets empty strings for both chunks and throws a confusing `Failed to parse Supabase session from cookie` error.

This is common when copying `document.cookie` from the browser console, which returns all cookies as a single string where the auth token may not be chunked.

## Test plan

- [x] Builds cleanly (`npm run build`)
- [ ] Verify chunked `.0`/`.1` format still works (existing behavior)
- [ ] Verify single un-chunked cookie format now works
- [ ] Verify raw JSON session string now works
- [ ] Verify error message is clear when no valid format is found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session parsing: now accepts a raw JSON session cookie first, then reliably falls back to both chunked and single-cookie formats. Error messages updated to clearly indicate accepted cookie formats when parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->