### PR TITLE
Handle base64- prefixed Supabase session cookies

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,13 @@ export const SUPABASE_COOKIE_PREFIX = "sb-ujasntkfphywizsdaapi-auth-token";
 /** Refresh the token this many seconds before it actually expires. */
 export const TOKEN_REFRESH_BUFFER_SECONDS = 300;
 
+/**
+ * Per-cookie chunk size used when splitting large Supabase sessions across
+ * `.0`, `.1`, ... cookies. Matches `@supabase/ssr`'s default — 3180 bytes
+ * leaves headroom below the common 4KB browser cookie limit.
+ */
+export const COOKIE_CHUNK_SIZE = 3180;
+
 /** Maximum image size in bytes to fetch (10MB). */
 export const MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -127,12 +127,13 @@ export class MobbinAuth {
    * Parse the Supabase session JSON from the raw cookie string.
    *
    * Supabase SSR writes the session in one of two formats:
-   *   1. Legacy — URL-encoded JSON, optionally split across `.0`/`.1` chunks.
+   *   1. Legacy — URL-encoded JSON, optionally split across `.0`/`.1`/... chunks.
    *   2. `base64-` — the literal prefix `base64-` followed by base64-encoded
    *      JSON, also optionally chunked. Chunking happens by byte-splitting the
    *      full `base64-...` string, so only the first chunk carries the prefix.
    *
-   * We detect the format by looking at the reassembled chunk 0.
+   * Chunks are read in order (`.0`, `.1`, `.2`, ...) until the first gap, which
+   * matches how `@supabase/ssr` reassembles cookies.
    */
   private static parseSessionFromCookie(cookie: string): SupabaseSession {
     const cookies = cookie.split("; ").reduce<Record<string, string>>((acc, part) => {
@@ -143,12 +144,21 @@ export class MobbinAuth {
       return acc;
     }, {});
 
-    // Supabase only splits the session into `.0`/`.1` chunks when the value
-    // exceeds the ~4KB single-cookie limit. Smaller sessions are written to
-    // the bare cookie name with no suffix, so fall back to that.
-    const chunk0 = cookies[`${SUPABASE_COOKIE_PREFIX}.0`] ?? cookies[SUPABASE_COOKIE_PREFIX] ?? "";
-    const chunk1 = cookies[`${SUPABASE_COOKIE_PREFIX}.1`] ?? "";
-    const joined = chunk0 + chunk1;
+    // For small sessions Supabase writes the whole value under the bare name
+    // (no `.N` suffix). Otherwise it splits into `.0`, `.1`, ... by byte
+    // length. Prefer the chunked form and fall back to the bare cookie.
+    let joined: string;
+    if (cookies[`${SUPABASE_COOKIE_PREFIX}.0`] !== undefined) {
+      const parts: string[] = [];
+      for (let i = 0; ; i++) {
+        const part = cookies[`${SUPABASE_COOKIE_PREFIX}.${i}`];
+        if (part === undefined) break;
+        parts.push(part);
+      }
+      joined = parts.join("");
+    } else {
+      joined = cookies[SUPABASE_COOKIE_PREFIX] ?? "";
+    }
 
     let combined: string;
     if (joined.startsWith("base64-")) {
@@ -157,7 +167,7 @@ export class MobbinAuth {
       } catch {
         throw new Error(
           `Failed to base64-decode Supabase session cookie. ` +
-            `Make sure MOBBIN_AUTH_COOKIE contains the complete '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies.`,
+            `Make sure MOBBIN_AUTH_COOKIE contains the complete '${SUPABASE_COOKIE_PREFIX}.*' cookies.`,
         );
       }
     } else {
@@ -169,20 +179,31 @@ export class MobbinAuth {
     } catch {
       throw new Error(
         `Failed to parse Supabase session from cookie. ` +
-          `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies.`,
+          `Make sure MOBBIN_AUTH_COOKIE contains the '${SUPABASE_COOKIE_PREFIX}.*' cookies.`,
       );
     }
   }
 
   /**
-   * Rebuild the raw cookie string from a session object.
-   * Splits the JSON across two cookies to match Supabase's chunking behavior.
+   * Rebuild the raw cookie string from a session object in the `base64-`
+   * format that Mobbin's server expects. Sessions larger than
+   * {@link COOKIE_CHUNK_SIZE} bytes are split across `.0`, `.1`, ... chunks
+   * (matching `@supabase/ssr`'s chunker) — the legacy URL-encoded form is
+   * rejected as "unauthenticated" by Mobbin's API routes.
    */
   private static buildCookieString(session: SupabaseSession): string {
-    const encoded = encodeURIComponent(JSON.stringify(session));
-    const midpoint = Math.ceil(encoded.length / 2);
-    const chunk0 = encoded.substring(0, midpoint);
-    const chunk1 = encoded.substring(midpoint);
-    return `${SUPABASE_COOKIE_PREFIX}.0=${chunk0}; ${SUPABASE_COOKIE_PREFIX}.1=${chunk1}`;
+    const value = "base64-" + Buffer.from(JSON.stringify(session), "utf-8").toString("base64");
+    const chunks: string[] = [];
+    for (let i = 0; i < value.length; i += COOKIE_CHUNK_SIZE) {
+      chunks.push(value.slice(i, i + COOKIE_CHUNK_SIZE));
+    }
+    return chunks.map((chunk, i) => `${SUPABASE_COOKIE_PREFIX}.${i}=${chunk}`).join("; ");
   }
 }
+
+/**
+ * Per-cookie chunk size used when splitting large sessions. Matches
+ * `@supabase/ssr`'s default — 3180 bytes leaves headroom below the
+ * common 4KB browser cookie limit.
+ */
+const COOKIE_CHUNK_SIZE = 3180;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,6 +3,7 @@ import {
   SUPABASE_ANON_KEY,
   SUPABASE_COOKIE_PREFIX,
   TOKEN_REFRESH_BUFFER_SECONDS,
+  COOKIE_CHUNK_SIZE,
 } from "../constants.js";
 
 export interface SupabaseSession {
@@ -160,19 +161,11 @@ export class MobbinAuth {
       joined = cookies[SUPABASE_COOKIE_PREFIX] ?? "";
     }
 
-    let combined: string;
-    if (joined.startsWith("base64-")) {
-      try {
-        combined = Buffer.from(joined.slice("base64-".length), "base64").toString("utf-8");
-      } catch {
-        throw new Error(
-          `Failed to base64-decode Supabase session cookie. ` +
-            `Make sure MOBBIN_AUTH_COOKIE contains the complete '${SUPABASE_COOKIE_PREFIX}.*' cookies.`,
-        );
-      }
-    } else {
-      combined = decodeURIComponent(joined);
-    }
+    // Buffer.from(..., "base64") never throws — invalid input silently produces
+    // garbage bytes, which then fail in the JSON.parse below with a clearer error.
+    const combined = joined.startsWith("base64-")
+      ? Buffer.from(joined.slice("base64-".length), "base64").toString("utf-8")
+      : decodeURIComponent(joined);
 
     try {
       return JSON.parse(combined) as SupabaseSession;
@@ -200,10 +193,3 @@ export class MobbinAuth {
     return chunks.map((chunk, i) => `${SUPABASE_COOKIE_PREFIX}.${i}=${chunk}`).join("; ");
   }
 }
-
-/**
- * Per-cookie chunk size used when splitting large sessions. Matches
- * `@supabase/ssr`'s default — 3180 bytes leaves headroom below the
- * common 4KB browser cookie limit.
- */
-const COOKIE_CHUNK_SIZE = 3180;

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -125,7 +125,14 @@ export class MobbinAuth {
 
   /**
    * Parse the Supabase session JSON from the raw cookie string.
-   * The session is split across two cookies (`.0` and `.1`) and URL-encoded.
+   *
+   * Supabase SSR writes the session in one of two formats:
+   *   1. Legacy — URL-encoded JSON, optionally split across `.0`/`.1` chunks.
+   *   2. `base64-` — the literal prefix `base64-` followed by base64-encoded
+   *      JSON, also optionally chunked. Chunking happens by byte-splitting the
+   *      full `base64-...` string, so only the first chunk carries the prefix.
+   *
+   * We detect the format by looking at the reassembled chunk 0.
    */
   private static parseSessionFromCookie(cookie: string): SupabaseSession {
     const cookies = cookie.split("; ").reduce<Record<string, string>>((acc, part) => {
@@ -136,15 +143,26 @@ export class MobbinAuth {
       return acc;
     }, {});
 
-    // Supabase only splits the session into `.0`/`.1` chunks when the JSON
+    // Supabase only splits the session into `.0`/`.1` chunks when the value
     // exceeds the ~4KB single-cookie limit. Smaller sessions are written to
     // the bare cookie name with no suffix, so fall back to that.
-    const chunk0 =
-      cookies[`${SUPABASE_COOKIE_PREFIX}.0`] ??
-      cookies[SUPABASE_COOKIE_PREFIX] ??
-      "";
+    const chunk0 = cookies[`${SUPABASE_COOKIE_PREFIX}.0`] ?? cookies[SUPABASE_COOKIE_PREFIX] ?? "";
     const chunk1 = cookies[`${SUPABASE_COOKIE_PREFIX}.1`] ?? "";
-    const combined = decodeURIComponent(chunk0 + chunk1);
+    const joined = chunk0 + chunk1;
+
+    let combined: string;
+    if (joined.startsWith("base64-")) {
+      try {
+        combined = Buffer.from(joined.slice("base64-".length), "base64").toString("utf-8");
+      } catch {
+        throw new Error(
+          `Failed to base64-decode Supabase session cookie. ` +
+            `Make sure MOBBIN_AUTH_COOKIE contains the complete '${SUPABASE_COOKIE_PREFIX}.0' and '.1' cookies.`,
+        );
+      }
+    } else {
+      combined = decodeURIComponent(joined);
+    }
 
     try {
       return JSON.parse(combined) as SupabaseSession;


### PR DESCRIPTION
## Summary

Fixes two related bugs that together prevented `mobbin-mcp` from working for anyone whose Supabase session is in the newer `base64-` cookie format (the default for larger sessions — e.g. Google-SSO users).

### Bug 1 — parser rejects `base64-` cookies (commit 1)

`parseSessionFromCookie` ran `decodeURIComponent` + `JSON.parse` on the reassembled chunks. For a `base64-`-formatted cookie the reassembled string starts with the literal `base64-` prefix, so `JSON.parse` throws `SyntaxError: Unexpected token 'b'` and startup fails with `"Failed to parse Supabase session from cookie"`.

Detect the `base64-` prefix on the joined chunks and base64-decode before `JSON.parse`; fall back to the legacy URL-encoded path otherwise.

### Bug 2 — rebuilt cookie is not accepted by Mobbin (commit 2)

Even after Bug 1 is fixed, every authenticated endpoint (`search-apps`, `search-screens`, `search-flows`, `collection/fetch-collections`, `search-bar/search`, `popular-apps/...`) returned HTTP 200 with `{"error":{"message":"unauthenticated"}}`, while unauthenticated routes (`dictionary-definitions`, `searchable-apps/{platform}`) worked.

Root cause: `buildCookieString` always emitted legacy URL-encoded JSON, but Mobbin's Next.js server uses `@supabase/ssr` server-side which no longer accepts that format — it rejects the request as anonymous. A direct comparison against the same session confirmed: `base64-`-formatted cookie → 200 with real data, legacy format → 200 with `"unauthenticated"`.

Now emit the cookie in the `base64-` format Supabase SSR writes today. While here:

- **Chunk at 3180 bytes** (matching `@supabase/ssr`'s chunker) instead of a 50/50 midpoint split, so large sessions stay under the ~4KB per-cookie limit.
- **Read all `.0`, `.1`, `.2`, ... chunks** on parse until the first gap, instead of only `.0`/`.1`, so sessions that spill into 3+ chunks roundtrip cleanly.

## Test plan

Synthetic — all combinations round-trip cleanly:
- [x] legacy URL-encoded JSON, single cookie
- [x] legacy URL-encoded JSON, `.0`/`.1` chunked
- [x] `base64-` prefix, single cookie
- [x] `base64-` prefix, `.0`/`.1` chunked (previously broken on parse)
- [x] `base64-` prefix, 3-chunk (previously broken on parse — only `.0`/`.1` were read)
- [x] `fromSession(x).getCookieValue()` → `fromCookie(...)` roundtrip produces equal session
- [x] garbage input still surfaces a clear parse error

End-to-end with a live Mobbin session (after commit 2):
- [x] `searchApps`, `searchScreens`, `searchFlows`, `getPopularApps`, `getCollections`, `autocompleteSearch`, `getDictionaryDefinitions` — all return real data
- [x] `npm run lint`, `npm run format:check`, `npm run build` all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved session authentication handling with enhanced support for large sessions that are distributed across multiple cookies, providing better performance and overall stability in various authentication scenarios
  * Added support for Supabase Server-Side Rendering session format for improved compatibility and seamless integration with Supabase authentication backends

<!-- end of auto-generated comment: release notes by coderabbit.ai -->