### PR TITLE
Restrict mobbin_search_apps sort_by to publishedAt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,10 +68,7 @@ async function main() {
         .array(z.string())
         .optional()
         .describe("Filter by app categories (e.g., 'Finance', 'AI', 'Music & Audio')"),
-      sort_by: z
-        .enum(["publishedAt", "trending", "popular", "top"])
-        .default("publishedAt")
-        .describe("Sort order"),
+      sort_by: z.enum(["publishedAt"]).default("publishedAt").describe("Sort order"),
       page_size: z.number().min(1).max(50).default(DEFAULT_PAGE_SIZE).describe("Results per page"),
       page_index: z.number().min(0).default(0).describe("Page number (0-indexed)"),
     },


### PR DESCRIPTION
## Summary

`POST /api/content/search-apps` only accepts `sortBy: "publishedAt"` — every other value in the advertised enum (`trending`, `popular`, `top`) is rejected with HTTP 400 and an empty body, making the tool fail whenever the model picks a non-default sort.

## Evidence

Probed the endpoint directly against a live session:

| sortBy        | search-apps | search-screens | search-flows |
|---------------|-------------|----------------|--------------|
| publishedAt   | 200         | 200            | 200          |
| trending      | **400**     | 200            | 200          |
| popular       | **400**     | 400            | 400          |
| top           | **400**     | 400            | 400          |
| latest        | **400**     | 400            | 400          |

`mobbin_search_screens` and `mobbin_search_flows` already advertise only the two values they accept (`publishedAt`, `trending`). `mobbin_search_apps` claimed four — only one works.

For "popular" apps, `mobbin_popular_apps` (which wraps `/api/popular-apps/fetch-popular-apps-with-preview-screens`) is already the correct tool; this PR doesn't remove that capability.

## Design note

Kept `sort_by` as a single-value Zod union rather than dropping the parameter entirely, so the call shape stays stable for callers and there's room to extend if Mobbin adds more valid values.

## Test plan

- [x] `npm run build`, `npm run lint` clean
- [x] Before: `mobbin_search_apps` with `sort_by: "trending"` → `Mobbin API error: 400 Bad Request - /api/content/search-apps`
- [x] After: the invalid values are no longer exposed to the model, so the tool only ever sends what the server accepts

## Related

Standalone from #3 (the base64 cookie fix), but that PR is what got this bug unblocked — before it, every `search-apps` call failed with `unauthenticated` regardless of `sort_by`.