### PR TITLE
ci: drop pre-1.0 bump flags from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,9 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "draft": false,
-      "prerelease": false,
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": false
+      "prerelease": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: false` from `release-please-config.json`. These are pre-1.0 settings that misapplied to a project already at 1.0.5 and caused release-please to propose downgrading to 1.0.0 (PR #6, now closed).

## Context
Earlier today PR #5 wired up release-please. On the first run it opened PR #6 proposing a release at version `1.0.0` — a downgrade — because:
1. The repo had no git tags from prior releases (versions had been hand-edited in `package.json`), and
2. The pre-1.0 bump flags told release-please to treat this as a pre-release project.

This PR fixes (2). Issue (1) was already addressed by pushing a `v1.0.5` git tag to anchor release-please at the correct baseline.

## Test plan
- [ ] Merge this PR — should not trigger a release (commit is `ci:` type)
- [ ] Confirm release-please run on the merge does not reopen a downgrade PR
- [ ] Land a follow-up PR with a `fix:` commit; confirm release-please opens a release PR for `1.0.6` (patch bump from `1.0.5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)