### PR TITLE
ci: allow manual dispatch of release-please and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'pdcolandrea'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -12,6 +13,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch' || github.actor == 'pdcolandrea'
     steps:
       - uses: googleapis/release-please-action@v4
         with:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch:` triggers to both `release-please.yml` and `publish.yml`, exposing a "Run workflow" button in the Actions UI and enabling `gh workflow run`.
- Restricts manual dispatch to @pdcolandrea via `if: github.actor == 'pdcolandrea'` on each job.

## Why
- Useful for forcing a release-please re-scan after config tweaks (no need to fake a commit).
- Useful for re-running a failed `publish.yml` without creating a new release.

## Permissions model
GitHub already restricts `workflow_dispatch` to users with write access on the repo. The actor-check is belt-and-suspenders — keeps the restriction explicit if collaborators are added later. Automatic runs (push to master, release published) are unaffected by the guard.

## How to use after merge
```
gh workflow run release-please.yml
gh workflow run publish.yml
```
Or click "Run workflow" in the Actions tab.

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run release-please.yml` — confirm it executes (should be a no-op since no new commits)
- [ ] Verify `if` guard works as expected (only @pdcolandrea can manually trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)