### PR TITLE
ci: add --force to npm self-upgrade in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@latest --force
       - run: npm ci
       - run: npm run build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Adds \`--force\` to \`npm install -g npm@latest\` in publish.yml to work around a known transient self-upgrade bug.

## Why
The first manual dispatch of publish.yml (for v1.0.6) failed with:
\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`
Cause: \`npm install -g npm@latest\` rewrites npm's own dependency tree while still executing, so the running npm process loses module resolution mid-upgrade. \`--force\` tells npm to proceed past the transient inconsistency. Well-documented CI workaround.

## After merge
Re-run \`gh workflow run publish.yml\` to ship 1.0.6 to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)