### PR TITLE
feat: scope mobbin_get_filters to a single facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,17 @@ Mobbin has no public API. This server was built by reverse-engineering their int
 | `mobbin_popular_apps`      | Get popular apps grouped by category                                                         |
 | `mobbin_list_collections`  | List your saved collections                                                                  |
 | `mobbin_get_screen_detail` | Fetch a full screenshot image for a specific screen, with optional dominant color extraction |
-| `mobbin_get_filters`       | Get all available filter values (categories, patterns, elements, actions)                    |
+| `mobbin_get_filters`       | Get valid values for one filter facet — `kind: "categories" \| "patterns" \| "elements" \| "actions"` |
+
+### Migration: `mobbin_get_filters`
+
+The no-arg form was removed. The full taxonomy in one response exceeded the MCP per-tool-result token cap and forced the agent to read the result back from a temp file. Pass a `kind` to scope the response to one facet:
+
+```ts
+mobbin_get_filters({ kind: "patterns" })                               // newline list of names
+mobbin_get_filters({ kind: "patterns", include_definitions: true })    // bullets with descriptions
+mobbin_get_filters({ kind: "patterns", include_counts: true })         // bullets with content counts
+```
 
 ## Setup
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,26 @@ import {
   formatFlows,
   formatCollections,
   formatScreenDetail,
+  formatFilterFacet,
 } from "./utils/formatting.js";
 import { DEFAULT_PAGE_SIZE } from "./constants.js";
+import type { DictionaryCategory } from "./types.js";
 import { readStoredSession, writeStoredSession } from "./utils/auth-store.js";
+
+type FilterKind = "categories" | "patterns" | "elements" | "actions";
+
+// Substring match on the upstream category slug. Loose on purpose: the API has
+// shipped a few different slug formats (`app_categories` vs `appCategories`),
+// and a substring keeps us resilient. If we ever see a kind match zero or
+// multiple categories in practice, tighten to exact strings here.
+const KIND_MATCHERS: Record<FilterKind, (slug: string) => boolean> = {
+  categories: (s) => s.includes("categor"),
+  patterns: (s) => s.includes("pattern"),
+  elements: (s) => s.includes("element"),
+  actions: (s) => s.includes("action"),
+};
+
+const DICT_TTL_MS = 60 * 60 * 1000;
 
 async function main() {
   // CLI subcommand routing
@@ -49,6 +66,14 @@ async function main() {
   }
 
   const client = new MobbinApiClient(auth);
+
+  let dictCache: { at: number; value: DictionaryCategory[] } | null = null;
+  async function getDictionary(): Promise<DictionaryCategory[]> {
+    if (dictCache && Date.now() - dictCache.at < DICT_TTL_MS) return dictCache.value;
+    const result = await client.getDictionaryDefinitions();
+    dictCache = { at: Date.now(), value: result.value };
+    return dictCache.value;
+  }
 
   const server = new McpServer({
     name: "mobbin",
@@ -270,38 +295,47 @@ async function main() {
   // --- Filter Taxonomy ---
   server.tool(
     "mobbin_get_filters",
-    "Get all available filter options for Mobbin search — app categories, screen patterns, UI elements, and flow actions. Use this to discover valid filter values for other search tools.",
-    {},
-    async () => {
-      const result = await client.getDictionaryDefinitions();
-      const categories = result.value;
-
-      const text = categories
-        .map((cat) => {
-          const entries = (cat.subCategories ?? [])
-            .flatMap((sub) => sub.entries ?? [])
-            .filter((e) => !e.hidden)
-            .map((e) => {
-              const counts = Object.entries(e.contentCounts ?? {})
-                .flatMap(([type, platforms]) => {
-                  // Two shapes in the wild: { type: { platform: count } } and { type: count }.
-                  if (platforms && typeof platforms === "object") {
-                    return Object.entries(platforms).map(([p, c]) => `${p} ${type}: ${c}`);
-                  }
-                  if (typeof platforms === "number") {
-                    return [`${type}: ${platforms}`];
-                  }
-                  return [];
-                })
-                .join(", ");
-              return `  - **${e.displayName}**: ${e.definition.substring(0, 80)}${e.definition.length > 80 ? "..." : ""}${counts ? ` (${counts})` : ""}`;
-            });
-
-          return `## ${cat.displayName} (${cat.experience})\nSlug: \`${cat.slug}\`\n${entries.join("\n")}`;
-        })
-        .join("\n\n");
-
-      return { content: [{ type: "text", text }] };
+    "Get valid values for one Mobbin filter facet (categories, patterns, elements, or actions). " +
+      "Returns a plain newline list of names by default — pass include_definitions or include_counts to enrich. " +
+      "Use the result to build the appCategories/screenPatterns/screenElements/flowActions params on the search tools.",
+    {
+      kind: z
+        .enum(["categories", "patterns", "elements", "actions"])
+        .describe(
+          "Which filter facet to fetch. Use the kind matching the search-tool param you're filling: " +
+            "'categories' → appCategories, 'patterns' → screenPatterns, " +
+            "'elements' → screenElements, 'actions' → flowActions.",
+        ),
+      include_definitions: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Include the human-readable definition for each value. Off by default to keep the response small.",
+        ),
+      include_counts: z
+        .boolean()
+        .default(false)
+        .describe(
+          "Include per-tag content counts. Off by default — counts aren't needed to construct queries.",
+        ),
+    },
+    async ({ kind, include_definitions, include_counts }) => {
+      try {
+        const all = await getDictionary();
+        const matcher = KIND_MATCHERS[kind];
+        const matched = all.filter((cat) => matcher(cat.slug.toLowerCase()));
+        const text = formatFilterFacet(matched, {
+          includeDefinitions: include_definitions,
+          includeCounts: include_counts,
+        });
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text" as const, text: `Failed to fetch filters: ${message}` }],
+          isError: true,
+        };
+      }
     },
   );
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -175,10 +175,10 @@ export function formatFilterFacet(
   if (entries.length === 0) return "No filter values found.";
 
   if (!opts.includeDefinitions && !opts.includeCounts) {
-    return entries.map((e) => e.displayName).join("\n");
+    return truncate(entries.map((e) => e.displayName).join("\n"));
   }
 
-  return entries
+  const text = entries
     .map((e) => {
       const parts = [`- **${e.displayName}**`];
       if (opts.includeDefinitions && e.definition) parts.push(e.definition);
@@ -189,6 +189,7 @@ export function formatFilterFacet(
       return parts.join(" — ");
     })
     .join("\n");
+  return truncate(text);
 }
 
 function truncate(text: string): string {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -1,5 +1,11 @@
 import { CHARACTER_LIMIT } from "../constants.js";
-import type { AppResult, ScreenResult, FlowResult, Collection } from "../types.js";
+import type {
+  AppResult,
+  ScreenResult,
+  FlowResult,
+  Collection,
+  DictionaryCategory,
+} from "../types.js";
 
 export function formatApps(apps: AppResult[]): string {
   if (apps.length === 0) return "No apps found.";
@@ -136,6 +142,53 @@ export function formatScreenDetail(params: {
   lines.push(`- **Source URL**: ${params.screenUrl}`);
 
   return lines.join("\n");
+}
+
+type ContentCounts =
+  DictionaryCategory["subCategories"][number]["entries"][number]["contentCounts"];
+
+// Three shapes in the wild: { type: { platform: count } }, { type: count }, or null.
+// Originally proven inline by commit 23592d2; extracted so formatFilterFacet can reuse.
+export function formatContentCounts(counts: ContentCounts): string {
+  return Object.entries(counts ?? {})
+    .flatMap(([type, platforms]) => {
+      if (platforms && typeof platforms === "object") {
+        return Object.entries(platforms).map(([p, c]) => `${p} ${type}: ${c}`);
+      }
+      if (typeof platforms === "number") {
+        return [`${type}: ${platforms}`];
+      }
+      return [];
+    })
+    .join(", ");
+}
+
+export function formatFilterFacet(
+  categories: DictionaryCategory[],
+  opts: { includeDefinitions: boolean; includeCounts: boolean },
+): string {
+  const entries = categories
+    .flatMap((cat) => cat.subCategories ?? [])
+    .flatMap((sub) => sub.entries ?? [])
+    .filter((e) => !e.hidden);
+
+  if (entries.length === 0) return "No filter values found.";
+
+  if (!opts.includeDefinitions && !opts.includeCounts) {
+    return entries.map((e) => e.displayName).join("\n");
+  }
+
+  return entries
+    .map((e) => {
+      const parts = [`- **${e.displayName}**`];
+      if (opts.includeDefinitions && e.definition) parts.push(e.definition);
+      if (opts.includeCounts) {
+        const counts = formatContentCounts(e.contentCounts);
+        if (counts) parts.push(`(${counts})`);
+      }
+      return parts.join(" — ");
+    })
+    .join("\n");
 }
 
 function truncate(text: string): string {


### PR DESCRIPTION
Closes #15

## Summary
- `mobbin_get_filters` now requires a `kind` enum (`categories` | `patterns` | `elements` | `actions`) and accepts two opt-in flags (`include_definitions`, `include_counts`)
- Default response is a plain newline list of names — small enough to fit in one tool result, easy for the agent to copy a value straight into the next call
- Module-level cache (1h TTL) so the four kinds share a single upstream fetch
- Extracted the three-shape `contentCounts` formatting (proven by 23592d2) into `formatContentCounts()`; new `formatFilterFacet()` reuses it for the enriched output

## Why
The no-arg form returned the full filter taxonomy with definitions and counts in one ~76k-char response, exceeding the MCP per-tool-result token cap. The harness saved it to a temp file and the agent had to read it back in chunks.

## Breaking change
The no-arg form is gone. Migration note added to the README.

```ts
mobbin_get_filters({ kind: "patterns" })                            // newline list of names
mobbin_get_filters({ kind: "patterns", include_definitions: true }) // bullets with descriptions
mobbin_get_filters({ kind: "patterns", include_counts: true })      // bullets with content counts
```

## Test plan
- [x] `npm run build` passes
- [x] `npm run format:check` passes
- [ ] Live smoke test with a real session: `mobbin_get_filters({ kind: "patterns" })` returns a newline list well under 25k chars
- [ ] `include_definitions: true` re-adds descriptions; `include_counts: true` re-adds counts
- [ ] `mobbin_get_filters({})` is rejected by Zod (`kind` is required)
- [ ] Verify the four `KIND_MATCHERS` substrings each match exactly one upstream category by logging `cat.slug` once on first run; if any kind matches zero or multiple, tighten to exact slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)