### PR TITLE
feat: add mobbin_get_app_screens and mobbin_get_app_flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ Mobbin has no public API. This server was built by reverse-engineering their int
 | `mobbin_search_screens`    | Search screens by UI patterns, elements, or text content                                     |
 | `mobbin_search_flows`      | Search user flows by action type (e.g., onboarding, checkout)                                |
 | `mobbin_quick_search`      | Fast autocomplete search for apps by name                                                    |
+| `mobbin_get_app_screens`   | Get every screen for one app (pair with `quick_search` to drill into a specific app)         |
+| `mobbin_get_app_flows`     | Get every user flow for one app (pair with `quick_search` to drill into a specific app)      |
 | `mobbin_popular_apps`      | Get popular apps grouped by category                                                         |
 | `mobbin_list_collections`  | List your saved collections                                                                  |
 | `mobbin_get_screen_detail` | Fetch a full screenshot image for a specific screen, with optional dominant color extraction |
 | `mobbin_get_filters`       | Get valid values for one filter facet — `kind: "categories" \| "patterns" \| "elements" \| "actions"` |
+
+### Drilling into a specific app
+
+`mobbin_search_screens` and `mobbin_search_flows` index Mobbin globally — they don't accept an `app_id` filter (the upstream API ignores per-app filters silently). For "show me Notion's onboarding"-style queries, use the two-step path: `mobbin_quick_search` to look up the app's `id`, then `mobbin_get_app_screens` or `mobbin_get_app_flows` with that `app_id`. The detail tools read from Mobbin's SSR'd app-detail page, so they return everything Mobbin has for that app.
 
 ### Migration: `mobbin_get_filters`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   formatCollections,
   formatScreenDetail,
   formatFilterFacet,
+  formatAppPageScreens,
 } from "./utils/formatting.js";
 import { DEFAULT_PAGE_SIZE } from "./constants.js";
 import type { DictionaryCategory } from "./types.js";
@@ -233,6 +234,68 @@ async function main() {
         .join("\n\n");
 
       return { content: [{ type: "text", text }] };
+    },
+  );
+
+  // --- Get App Screens ---
+  // The documented `search-screens` endpoint silently ignores per-app filters,
+  // so we can't drill into a single app via the search API. Instead, this tool
+  // (and `mobbin_get_app_flows`) reads from the SSR'd app-detail page, which
+  // is the same source the Mobbin web UI uses.
+  server.tool(
+    "mobbin_get_app_screens",
+    "Get all screens for a specific app on Mobbin. Pair with mobbin_quick_search to drill into one app: quick_search → app_id → get_app_screens. Returns every screen for that app with patterns, elements, and dimensions.",
+    {
+      app_id: z
+        .string()
+        .uuid()
+        .describe("App ID from mobbin_quick_search"),
+      platform: z.enum(["ios", "android", "web"]).default("ios").describe("App platform"),
+      page_size: z
+        .number()
+        .min(1)
+        .max(50)
+        .default(DEFAULT_PAGE_SIZE)
+        .describe("Results per page"),
+      page_index: z.number().min(0).default(0).describe("Page number (0-indexed)"),
+    },
+    async ({ app_id, platform, page_size, page_index }) => {
+      const { screens, appName } = await client.getAppPage({ appId: app_id, platform });
+      const start = page_index * page_size;
+      const slice = screens.slice(start, start + page_size);
+      const header = `**${appName}** (${platform}) — ${screens.length} screens total. Showing ${start + 1}–${Math.min(start + slice.length, screens.length)}.\n\n`;
+      return {
+        content: [{ type: "text", text: header + formatAppPageScreens(slice) }],
+      };
+    },
+  );
+
+  // --- Get App Flows ---
+  server.tool(
+    "mobbin_get_app_flows",
+    "Get all user flows for a specific app on Mobbin. Pair with mobbin_quick_search: quick_search → app_id → get_app_flows. Returns each flow's screens with hotspot data for prototyping.",
+    {
+      app_id: z
+        .string()
+        .uuid()
+        .describe("App ID from mobbin_quick_search"),
+      platform: z.enum(["ios", "android", "web"]).default("ios").describe("App platform"),
+      page_size: z
+        .number()
+        .min(1)
+        .max(50)
+        .default(DEFAULT_PAGE_SIZE)
+        .describe("Results per page"),
+      page_index: z.number().min(0).default(0).describe("Page number (0-indexed)"),
+    },
+    async ({ app_id, platform, page_size, page_index }) => {
+      const { flows, appName } = await client.getAppPage({ appId: app_id, platform });
+      const start = page_index * page_size;
+      const slice = flows.slice(start, start + page_size);
+      const header = `**${appName}** (${platform}) — ${flows.length} flows total. Showing ${start + 1}–${Math.min(start + slice.length, flows.length)}.\n\n`;
+      return {
+        content: [{ type: "text", text: header + formatFlows(slice) }],
+      };
     },
   );
 

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -22,6 +22,9 @@ import {
   popularAppsResponseSchema,
   collectionsResponseSchema,
   dictionaryDefinitionsResponseSchema,
+  appPagePayloadSchema,
+  appPageScreenSchema,
+  flowResultSchema,
 } from "./schemas.js";
 import type { MobbinAuth } from "./auth.js";
 import type {
@@ -35,6 +38,7 @@ import type {
   DictionaryCategory,
   ContentSearchResponse,
   ValueResponse,
+  AppPageScreen,
 } from "../types.js";
 
 /**
@@ -276,6 +280,56 @@ export class MobbinApiClient {
   }
 
   /**
+   * Fetch the SSR'd app-detail page for an app and return its embedded
+   * flows + screens. Mobbin's `/api/content/search-screens` and
+   * `/api/content/search-flows` ignore per-app filters silently — confirmed
+   * via probe — so the only authoritative per-app source is the HTML page
+   * at `/apps/{slug}-{platform}-{appId}/screens`. The page renders via
+   * Next.js Server Components and inlines the structured data inside
+   * `self.__next_f.push([1, "..."])` flight chunks; we concatenate the
+   * chunks, locate the `[{"value":[...]}, ...]` payload, and parse it.
+   *
+   * Slug derivation: looked up via `getSearchableApps`, kebab-cased.
+   * AppVersionId is NOT required — Mobbin redirects to the latest version.
+   *
+   * Endpoint: `GET /apps/{slug}-{platform}-{appId}/screens`
+   */
+  async getAppPage(params: {
+    appId: string;
+    platform: string;
+  }): Promise<{ flows: FlowResult[]; screens: AppPageScreen[]; appName: string; slug: string }> {
+    const allApps = await this.getSearchableApps(params.platform);
+    const app = allApps.find((a) => a.id === params.appId);
+    if (!app) {
+      throw new Error(
+        `App not found: appId=${params.appId} platform=${params.platform}. Use mobbin_quick_search to discover valid app IDs.`,
+      );
+    }
+    const slug = `${slugifyAppName(app.appName)}-${params.platform}-${params.appId}`;
+    const path = `/apps/${slug}/screens`;
+
+    const cookie = await this.auth.getCookieValue();
+    const res = await fetch(`${MOBBIN_BASE_URL}${path}`, {
+      headers: {
+        Cookie: cookie,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9",
+      },
+      redirect: "follow",
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Mobbin app page fetch failed: ${res.status} ${res.statusText} - ${path}`,
+      );
+    }
+    const html = await res.text();
+
+    const payload = extractAppPagePayload(html, path);
+    const flows = z.array(flowResultSchema).parse(payload[0].value);
+    const screens = z.array(appPageScreenSchema).parse(payload[1].value);
+    return { flows, screens, appName: app.appName, slug };
+  }
+
+  /**
    * Convert a Supabase storage URL to its Bytescale CDN equivalent.
    * Supabase storage URLs are not directly accessible — images are served via CDN.
    *
@@ -400,4 +454,91 @@ export class MobbinApiClient {
       .slice(0, maxColors)
       .map(([hex]) => hex);
   }
+}
+
+/**
+ * Mobbin's app slug is `<lowercase-kebab-app-name>-<platform>-<appId>`.
+ * Mobbin's slugifier strips ASCII punctuation and collapses whitespace runs to a single dash.
+ * "Linear Mobile" → "linear-mobile", "ChatGPT (AI)" → "chatgpt-ai".
+ */
+function slugifyAppName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Extract the structured payload (`[{value: flows}, {value: screens}, {value: meta}]`)
+ * from Mobbin's SSR'd app-detail HTML. The page streams data via
+ * `self.__next_f.push([1, "<chunk>"])` calls; concatenating the chunks gives
+ * the React Flight stream, which contains the JSON payload as a substring
+ * starting with `[{"value":[`. We locate that, walk forward with
+ * bracket/quote tracking, and JSON.parse the slice.
+ *
+ * Path is passed in for error attribution.
+ */
+function extractAppPagePayload(html: string, path: string): z.infer<typeof appPagePayloadSchema> {
+  const chunkRe = /self\.__next_f\.push\(\[1,\s*"((?:[^"\\]|\\.)*)"\s*\]\)/g;
+  let stream = "";
+  let m: RegExpExecArray | null;
+  while ((m = chunkRe.exec(html)) !== null) {
+    try {
+      stream += JSON.parse(`"${m[1]}"`) as string;
+    } catch {
+      // Skip malformed chunks — partial streams happen near end-of-document.
+    }
+  }
+
+  const start = stream.indexOf('[{"value":[');
+  if (start < 0) {
+    throw new Error(
+      `Could not locate app-page payload in ${path}. Mobbin may have changed its SSR format, or the slug resolved to a 404 page.`,
+    );
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let end = start;
+  for (; end < stream.length; end++) {
+    const c = stream[end];
+    if (inString) {
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (c === "\\") {
+        escape = true;
+        continue;
+      }
+      if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === "[" || c === "{") depth++;
+    else if (c === "]" || c === "}") {
+      depth--;
+      if (depth === 0) {
+        end++;
+        break;
+      }
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stream.slice(start, end));
+  } catch (err) {
+    throw new Error(
+      `Failed to parse app-page payload JSON in ${path}: ${(err as Error).message.slice(0, 200)}`,
+      { cause: err },
+    );
+  }
+  return appPagePayloadSchema.parse(parsed);
 }

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -186,6 +186,60 @@ export const autocompleteResponseSchema = z
   })
   .passthrough();
 
+/**
+ * Screens as embedded in the SSR'd app-detail page (`/apps/{slug}/screens`).
+ * Shape differs from `screenResultSchema` (the search-screens API): SSR carries
+ * extras like OCR boxes and `isAppKeyScreen`, but lacks `screenNumber`,
+ * `appCategory`, `popularityMetric`, etc. Used by `getAppPage`.
+ */
+export const ocrBoundingBoxSchema = z
+  .object({
+    text: z.string(),
+    bbox: z
+      .object({
+        x0: z.number(),
+        y0: z.number(),
+        x1: z.number(),
+        y1: z.number(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+export const appPageScreenSchema = z
+  .object({
+    type: z.string(),
+    id: z.string(),
+    screenUrl: z.string(),
+    createdAt: z.string(),
+    width: z.number(),
+    height: z.number(),
+    fullpageScreenUrl: z.string().nullable(),
+    screenElements: z.array(z.string()),
+    screenPatterns: z.array(z.string()),
+    isAppKeyScreen: z.boolean(),
+    appId: z.string(),
+    appName: z.string(),
+    appLogoUrl: z.string(),
+    platform: z.string(),
+    appVersionId: z.string(),
+    appVersionPublishedAt: z.string(),
+    ocrBoundingBoxes: z.array(ocrBoundingBoxSchema).nullable().optional(),
+  })
+  .passthrough();
+
+/**
+ * Top-level shape of the structured payload extracted from the SSR HTML —
+ * an array where `[0].value` is flows and `[1].value` is the flat screens list.
+ * `[2]` (and beyond) is dictionary metadata we ignore. Validate the inner
+ * arrays with their own schemas in code rather than locking the tuple length.
+ */
+export const appPagePayloadEntrySchema = z
+  .object({ value: z.unknown() })
+  .passthrough();
+
+export const appPagePayloadSchema = z.array(appPagePayloadEntrySchema).min(2);
+
 /** Wraps an item schema in the standard paginated `{ value: { searchRequestId, data: T[] } }` envelope. */
 export const contentSearchResponseSchema = <T extends z.ZodTypeAny>(item: T) =>
   z

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import type {
   dictionaryCategorySchema,
   popularAppEntrySchema,
   autocompleteResponseSchema,
+  appPageScreenSchema,
 } from "./services/schemas.js";
 
 /**
@@ -29,6 +30,7 @@ export type Collection = z.infer<typeof collectionSchema>;
 export type DictionaryCategory = z.infer<typeof dictionaryCategorySchema>;
 export type PopularAppEntry = z.infer<typeof popularAppEntrySchema>;
 export type AutocompleteResponse = z.infer<typeof autocompleteResponseSchema>;
+export type AppPageScreen = z.infer<typeof appPageScreenSchema>;
 
 /** Pagination params used by all `/api/content/search-*` endpoints. */
 export interface PaginationOptions {

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -5,6 +5,7 @@ import type {
   FlowResult,
   Collection,
   DictionaryCategory,
+  AppPageScreen,
 } from "../types.js";
 
 export function formatApps(apps: AppResult[]): string {
@@ -47,6 +48,28 @@ export function formatScreens(screens: ScreenResult[]): string {
       `- **App ID**: ${s.appId}`,
       `- **Screen ID**: ${s.id}`,
       s.metadata ? `- **Dimensions**: ${s.metadata.width}x${s.metadata.height}` : "",
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  );
+
+  return truncate(lines.join("\n\n"));
+}
+
+export function formatAppPageScreens(screens: AppPageScreen[]): string {
+  if (screens.length === 0) return "No screens found for this app.";
+
+  const lines = screens.map((s, i) =>
+    [
+      `### ${i + 1}. ${s.appName} — ${s.screenPatterns.join(", ") || "Screen"}`,
+      `- **App**: ${s.appName} (${s.platform})`,
+      `- **Patterns**: ${s.screenPatterns.join(", ") || "None"}`,
+      `- **Elements**: ${s.screenElements.join(", ") || "None"}`,
+      `- **Screen URL**: ${s.screenUrl}`,
+      `- **Screen ID**: ${s.id}`,
+      `- **App ID**: ${s.appId}`,
+      `- **Dimensions**: ${s.width}x${s.height}`,
+      s.isAppKeyScreen ? `- **Key screen**: yes` : "",
     ]
       .filter(Boolean)
       .join("\n"),


### PR DESCRIPTION
## Summary

Closes #16 — adds a path from "I know the app I care about" to "show me its screens or flows", which is the most common designer-style drill-down ("show me Notion's onboarding") and was previously unserveable.

- New `mobbin_get_app_screens({ app_id, platform })` — every screen for one app, with patterns/elements/dimensions
- New `mobbin_get_app_flows({ app_id, platform })` — every user flow for one app, with embedded screens + hotspots
- Intended workflow: `mobbin_quick_search → app_id → get_app_screens / get_app_flows`

## Why not just add `app_id` to `search_screens` / `search_flows`?

That was the original plan. The probe disproved it: `/api/content/search-screens` and `/api/content/search-flows` silently ignore every per-app filter field name we tried (`appId`, `appIds`, `appVersionId`, `appVersionIds`, `apps`, `app`) — `appCategories: ["Productivity"]` baseline returned 17,888 screens / "Opal" only; adding any app-id variant gave the same 17,888 / "Opal" result. The numbers and content don't change. Same story for flows (57,243 baseline, every variant ignored).

Confirmed via Playwright that Mobbin's web UI doesn't call `search-screens` for app pages either — it renders `/apps/{slug}/screens` via Next.js Server Components and inlines the data. So this PR reads from the same source the web UI uses.

## How it works

`MobbinApiClient.getAppPage()`:

1. Looks up `appName` via the existing `getSearchableApps(platform)` cache
2. Builds the canonical slug: `slugify(appName) + '-' + platform + '-' + appId`
3. GETs `/apps/{slug}/screens` with the session cookie
4. Concatenates every `self.__next_f.push([1, "..."])` chunk in the HTML
5. Locates the `[{"value":[…]}, …]` payload by anchor + balanced-bracket / quote-state walk
6. `JSON.parse` and validate via zod (`appPagePayloadSchema`, `appPageScreenSchema`, existing `flowResultSchema`)

`appVersionId` isn't required — Mobbin redirects to the latest version automatically.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/` clean
- [x] End-to-end probe (`scripts/probe-app-page.ts`, gitignored per repo convention) against Linear Mobile (ios) — 62 flows, 184 screens, every screen's `appId` matches the requested one
- [ ] Manual smoke test: register the MCP locally, run `quick_search → get_app_screens` for a couple of apps and confirm the formatted output is useful for design-research queries
- [ ] Spot-check `get_app_flows` with an app that has many flows (Linear's 62 flows includes "Onboarding" with 22 screens and the expected actions)

## Notes / follow-ups

- The probe also surfaced an unrelated regression: `search-apps` responses no longer carry the `value` wrapper, so `scripts/probe-schemas.ts` fails on it. Out of scope for #16; worth filing separately.
- This PR adds zero hits to the slow `search-*` endpoints; `getAppPage` reuses the existing `getSearchableApps` call (which is already part of `quick_search`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new tools to retrieve all screens and flows for a specific app with pagination support.

* **Documentation**
  * Updated guidance documenting the recommended two-step workflow for app-scoped queries: search for an app ID first, then use the new tools to retrieve screens or flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->