### PR TITLE
feat: add mobbin_get_collection to fetch saved collection items

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   formatScreens,
   formatFlows,
   formatCollections,
+  formatCollectionItems,
   formatScreenDetail,
   formatFilterFacet,
   formatAppPageScreens,
@@ -337,12 +338,101 @@ async function main() {
   server.tool(
     "mobbin_list_collections",
     "List your saved Mobbin collections with item counts. " +
-      "Use when: you need saved collection names, IDs, and app/screen/flow counts. This lists collection metadata only; collection item fetching is not available until mobbin_get_collection lands.",
+      "Use when: you need saved collection names, IDs, and app/screen/flow counts. " +
+      "Then call mobbin_get_collection with one of the returned IDs to enumerate the items inside.",
     {},
     async () => {
       const result = await client.getCollections();
       return {
         content: [{ type: "text", text: formatCollections(result.value) }],
+      };
+    },
+  );
+
+  // --- Get Collection Contents ---
+  // Mobbin pages collection contents per (contentType, platformType) bucket
+  // with a keyset cursor. By default we fetch the first page of every bucket
+  // hinted by the caller (or all of apps/screens/flows) and merge them so the
+  // agent can show a saved collection in one tool call. To page deeper inside
+  // a single bucket, pass `content_type` + `cursor`.
+  server.tool(
+    "mobbin_get_collection",
+    "Get the items saved inside a specific Mobbin collection (apps, screens, and/or flows). " +
+      "Pair with mobbin_list_collections to find the collection_id first. " +
+      "Returns items with the same screen URLs and IDs you'd get from mobbin_search_screens / mobbin_search_flows, so you can pass them straight to mobbin_get_screen_detail. " +
+      "Use when: the user asks about a saved collection's contents, or you want to enumerate / display what's inside one. " +
+      "For paging inside a single bucket, pass content_type plus the cursor returned in the previous response.",
+    {
+      collection_id: z.string().uuid().describe("Collection ID from mobbin_list_collections"),
+      platform: z
+        .enum(["mobile", "web"])
+        .default("mobile")
+        .describe(
+          "Mobbin buckets collection items as 'mobile' (iOS + Android) or 'web'. " +
+            "Check the counts from mobbin_list_collections to pick the right one.",
+        ),
+      content_type: z
+        .enum(["apps", "screens", "flows"])
+        .optional()
+        .describe(
+          "Restrict to a single bucket (apps, screens, or flows). " +
+            "Required when paginating with `cursor`. Omit to fetch the first page of all three buckets.",
+        ),
+      page_size: z
+        .number()
+        .min(1)
+        .max(50)
+        .default(DEFAULT_PAGE_SIZE)
+        .describe("Items per bucket per call"),
+      cursor: z
+        .object({
+          last_created_at: z.string(),
+          last_id: z.string(),
+        })
+        .optional()
+        .describe(
+          "Keyset cursor from the previous response. Only valid when content_type is also set.",
+        ),
+    },
+    async ({ collection_id, platform, content_type, page_size, cursor }) => {
+      if (cursor && !content_type) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "cursor requires content_type — Mobbin pages each bucket independently.",
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const buckets: Array<"apps" | "screens" | "flows"> = content_type
+        ? [content_type]
+        : ["apps", "screens", "flows"];
+
+      const sections: string[] = [];
+      for (const bucket of buckets) {
+        const result = await client.getCollectionContents({
+          collectionId: collection_id,
+          contentType: bucket,
+          platformType: platform,
+          pageSize: page_size,
+          cursor: cursor ? { lastCreatedAt: cursor.last_created_at, lastId: cursor.last_id } : null,
+        });
+        const header = `## ${bucket} (${platform}) — ${result.items.length} item(s)${
+          result.nextCursor ? " (more available)" : ""
+        }`;
+        const body = formatCollectionItems(result.items);
+        const footer = result.nextCursor
+          ? `\n\n_To page further: call mobbin_get_collection with content_type="${bucket}" and ` +
+            `cursor={ last_created_at: "${result.nextCursor.lastCreatedAt}", last_id: "${result.nextCursor.lastId}" }._`
+          : "";
+        sections.push(`${header}\n\n${body}${footer}`);
+      }
+
+      return {
+        content: [{ type: "text", text: sections.join("\n\n---\n\n") }],
       };
     },
   );

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -21,6 +21,7 @@ import {
   searchableAppsResponseSchema,
   popularAppsResponseSchema,
   collectionsResponseSchema,
+  collectionContentsResponseSchema,
   dictionaryDefinitionsResponseSchema,
   appPagePayloadSchema,
   appPageScreenSchema,
@@ -32,6 +33,8 @@ import type {
   ScreenResult,
   FlowResult,
   Collection,
+  CollectionItem,
+  CollectionCursor,
   SearchableApp,
   PopularAppEntry,
   AutocompleteResponse,
@@ -261,6 +264,67 @@ export class MobbinApiClient {
     return this.request("/api/collection/fetch-collections", collectionsResponseSchema, {
       method: "POST",
     });
+  }
+
+  /**
+   * Fetch one page of items inside a saved collection.
+   *
+   * Mobbin's web client buckets collection contents along two axes — `contentType`
+   * ({apps, screens, flows, sites, sections}) and `platformType` ({mobile, web}) —
+   * and pages each bucket independently using a keyset cursor. Pass `cursor: null`
+   * for the first page; for subsequent pages echo back the `nextCursor` returned
+   * by the previous call. Last-page detection: `nextCursor === null` (a short
+   * page).
+   *
+   * Errors come back as HTTP 200 with a server-side `{ error: { message } }`
+   * payload (e.g. unknown `collectionId` → "query error"); we promote those to
+   * thrown errors here so callers don't silently see an empty list.
+   *
+   * Endpoint: `POST /collections/api/fetch-collection-contents`
+   */
+  async getCollectionContents(params: {
+    collectionId: string;
+    contentType: "apps" | "screens" | "flows";
+    platformType: "mobile" | "web";
+    pageSize?: number;
+    cursor?: CollectionCursor | null;
+  }): Promise<{ items: CollectionItem[]; nextCursor: CollectionCursor | null }> {
+    const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
+    const result = await this.request(
+      "/collections/api/fetch-collection-contents",
+      collectionContentsResponseSchema,
+      {
+        method: "POST",
+        body: {
+          collectionId: params.collectionId,
+          contentType: params.contentType,
+          platformType: params.platformType,
+          paginationOptions: {
+            keysetPagination: params.cursor ?? {},
+            pageSize,
+          },
+        },
+      },
+    );
+
+    if (result.error) {
+      throw new Error(
+        `Mobbin collection-contents error (${result.error.code ?? "unknown"}): ${result.error.message}`,
+      );
+    }
+    if (!result.value) {
+      throw new Error("Mobbin collection-contents returned neither value nor error.");
+    }
+
+    const items = result.value.data;
+    const last = items[items.length - 1];
+    // The web client treats "page is full" as "there might be more". Apply the
+    // same rule so we never report exhausted when there's an exact-multiple boundary.
+    const nextCursor =
+      items.length === pageSize && last
+        ? { lastCreatedAt: last.created_at, lastId: last.id }
+        : null;
+    return { items, nextCursor };
   }
 
   /**

--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -134,6 +134,101 @@ export const collectionSchema = z
   })
   .passthrough();
 
+/**
+ * Item shape returned by `/collections/api/fetch-collection-contents`.
+ *
+ * The envelope is the same for every contentType — what varies is which inner
+ * payload key is populated (`screen`, `flow`, `app`, etc.) and which FK column
+ * is non-null (`app_screen_id`, `app_flow_id`, ...). The inner payloads are
+ * close to the search-API shapes but trimmed differently (for example, the
+ * `screen` payload exposes top-level `width`/`height` instead of `metadata`,
+ * and lacks `appCategory`/`popularityMetric`/`screenNumber`), so we keep them
+ * as `unknown()` and validate just the fields the formatter consumes.
+ */
+export const collectionItemScreenSchema = z
+  .object({
+    id: z.string(),
+    appId: z.string(),
+    appName: z.string(),
+    platform: z.string(),
+    screenUrl: z.string(),
+    width: z.number(),
+    height: z.number(),
+    screenPatterns: z.array(z.string()),
+    screenElements: z.array(z.string()),
+    appLogoUrl: z.string().optional(),
+    fullpageScreenUrl: z.string().nullable().optional(),
+  })
+  .passthrough();
+
+export const collectionItemFlowSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    appId: z.string(),
+    appName: z.string(),
+    platform: z.string(),
+    actions: z.array(z.string()),
+    videoUrl: z.string().nullable(),
+    screens: z.array(flowScreenSchema),
+  })
+  .passthrough();
+
+export const collectionItemAppSchema = z
+  .object({
+    id: z.string(),
+    appName: z.string(),
+    platform: z.string(),
+    appLogoUrl: z.string().optional(),
+    appTagline: z.string().optional(),
+  })
+  .passthrough();
+
+export const collectionItemSchema = z
+  .object({
+    id: z.string(),
+    collection_id: z.string(),
+    contentType: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    app_id: z.string().nullable(),
+    app_screen_id: z.string().nullable(),
+    app_flow_id: z.string().nullable(),
+    site_id: z.string().nullable(),
+    site_page_section_id: z.string().nullable(),
+    screen: collectionItemScreenSchema.optional(),
+    flow: collectionItemFlowSchema.optional(),
+    app: collectionItemAppSchema.optional(),
+  })
+  .passthrough();
+
+/**
+ * Successful response from `/collections/api/fetch-collection-contents`.
+ *
+ * The endpoint also returns HTTP 200 with `{ error: { message, code } }` for
+ * server-side failures (e.g., unknown `collectionId` -> "query error"). Those
+ * are turned into thrown errors by the API client so they surface at the call
+ * site instead of silently parsing as an empty result.
+ */
+export const collectionContentsResponseSchema = z
+  .object({
+    value: z
+      .object({
+        data: z.array(collectionItemSchema),
+        pageSize: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+    error: z
+      .object({
+        message: z.string(),
+        code: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
 export const dictionaryCategorySchema = z
   .object({
     slug: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,10 @@ import type {
   flowScreenSchema,
   flowResultSchema,
   collectionSchema,
+  collectionItemSchema,
+  collectionItemScreenSchema,
+  collectionItemFlowSchema,
+  collectionItemAppSchema,
   dictionaryCategorySchema,
   popularAppEntrySchema,
   autocompleteResponseSchema,
@@ -27,6 +31,16 @@ export type ScreenResult = z.infer<typeof screenResultSchema>;
 export type FlowScreen = z.infer<typeof flowScreenSchema>;
 export type FlowResult = z.infer<typeof flowResultSchema>;
 export type Collection = z.infer<typeof collectionSchema>;
+export type CollectionItem = z.infer<typeof collectionItemSchema>;
+export type CollectionItemScreen = z.infer<typeof collectionItemScreenSchema>;
+export type CollectionItemFlow = z.infer<typeof collectionItemFlowSchema>;
+export type CollectionItemApp = z.infer<typeof collectionItemAppSchema>;
+
+/** Keyset cursor returned by `getCollectionContents` for pagination. */
+export interface CollectionCursor {
+  lastCreatedAt: string;
+  lastId: string;
+}
 export type DictionaryCategory = z.infer<typeof dictionaryCategorySchema>;
 export type PopularAppEntry = z.infer<typeof popularAppEntrySchema>;
 export type AutocompleteResponse = z.infer<typeof autocompleteResponseSchema>;

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -4,6 +4,7 @@ import type {
   ScreenResult,
   FlowResult,
   Collection,
+  CollectionItem,
   DictionaryCategory,
   AppPageScreen,
 } from "../types.js";
@@ -102,6 +103,73 @@ export function formatFlows(flows: FlowResult[]): string {
     ]
       .filter(Boolean)
       .join("\n");
+  });
+
+  return truncate(lines.join("\n\n"));
+}
+
+/**
+ * Render a heterogenous list of saved-collection items (apps, screens, flows)
+ * with a `type` tag on each entry so the agent can disambiguate. Mirrors the
+ * field set used by `formatScreens` / `formatFlows` so screen URLs are
+ * directly usable downstream (e.g., as input to `mobbin_get_screen_detail`).
+ */
+export function formatCollectionItems(items: CollectionItem[]): string {
+  if (items.length === 0) return "No items in this section.";
+
+  const lines = items.map((item, i) => {
+    if (item.contentType === "screens" && item.screen) {
+      const s = item.screen;
+      return [
+        `### ${i + 1}. [screen] ${s.appName} — ${s.screenPatterns.join(", ") || "Screen"}`,
+        `- **App**: ${s.appName} (${s.platform})`,
+        `- **Patterns**: ${s.screenPatterns.join(", ") || "None"}`,
+        `- **Elements**: ${s.screenElements.join(", ") || "None"}`,
+        `- **Screen URL**: ${s.screenUrl}`,
+        `- **Screen ID**: ${s.id}`,
+        `- **App ID**: ${s.appId}`,
+        `- **Dimensions**: ${s.width}x${s.height}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (item.contentType === "flows" && item.flow) {
+      const f = item.flow;
+      const screenList = f.screens
+        .slice(0, 5)
+        .map((s, j) => {
+          const hotspot = s.hotspotX !== null ? " [hotspot]" : "";
+          return `  ${j + 1}.${hotspot} ${s.screenUrl}`;
+        })
+        .join("\n");
+      return [
+        `### ${i + 1}. [flow] ${f.name} — ${f.appName}`,
+        `- **App**: ${f.appName} (${f.platform})`,
+        `- **Actions**: ${f.actions.join(", ") || "None"}`,
+        `- **Flow ID**: ${f.id}`,
+        `- **Screens** (${f.screens.length} total):`,
+        screenList,
+        f.screens.length > 5 ? `  ... and ${f.screens.length - 5} more screens` : "",
+        f.videoUrl ? `- **Video**: ${f.videoUrl}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+    if (item.contentType === "apps" && item.app) {
+      const a = item.app;
+      return [
+        `### ${i + 1}. [app] ${a.appName}`,
+        a.appTagline ? `- **Tagline**: ${a.appTagline}` : "",
+        `- **Platform**: ${a.platform}`,
+        `- **App ID**: ${a.id}`,
+        a.appLogoUrl ? `- **Logo**: ${a.appLogoUrl}` : "",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    }
+    // Fallback for unhandled contentTypes (sites/sections aren't surfaced through
+    // the search tools yet, so skip detail rendering and just record the type).
+    return `### ${i + 1}. [${item.contentType}] (saved item id: ${item.id})`;
   });
 
   return truncate(lines.join("\n\n"));


### PR DESCRIPTION
## Summary
- Adds `mobbin_get_collection` MCP tool — fetches the items inside a saved Mobbin collection (apps, screens, flows) so the agent can finally read what's there, not just the metadata counts that `mobbin_list_collections` returns.
- New client method `MobbinApiClient.getCollectionContents()` hits the reverse-engineered `POST /collections/api/fetch-collection-contents`, paginating via Mobbin's `{lastCreatedAt, lastId}` keyset cursor.
- Server-side error envelopes (`{"error":{message,code}}` returned with HTTP 200, e.g. unknown `collectionId` → "query error") are promoted to thrown errors so callers never silently see an empty list.
- Updates `mobbin_list_collections` description to point at the new tool.

Closes #17

## API discovery notes
- Endpoint lives at `/collections/api/fetch-collection-contents` (note: `/collections/api/...`, not `/api/collection/...`).
- Body: `{ collectionId, contentType ∈ {apps,screens,flows,sites,sections}, platformType ∈ {mobile,web}, paginationOptions: { keysetPagination: {} | {lastCreatedAt,lastId}, pageSize } }`.
- `platformType` only has two values — `mobile` (iOS + Android merged) and `web`. The inner item's `platform` field carries the actual ios/android distinction.
- Each item is an envelope `{ id, collection_id, contentType, app_*_id, screen|flow|app, ... }`. Inner payloads are close to but not identical to the search-API shapes (e.g. `screen` exposes top-level `width`/`height` instead of `metadata`), so they get their own zod schemas with `passthrough()`.
- Found by greping the JS chunks loaded by an authenticated `/collections/{id}` page — the page shell SSRs no data, the client makes the call directly.

## Test plan
- [x] Probe (`scripts/probe-collection-items.ts`, ungitted per existing convention) hits real collections through `MobbinApiClient` + `formatCollectionItems`:
  - 3 non-empty buckets (mobile flows, mobile screens, web screens) render with screen URLs and IDs ready for `mobbin_get_screen_detail`
  - 5-item byte-onboard flow collection walks via cursor in 3 pages of 2 (2+2+1)
  - Bogus collection id throws `Mobbin collection-contents error (9XW9jw1e): query error`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [ ] Manual smoke test in an MCP client after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve items from saved Mobbin collections with filtering by platform and content type (apps/screens/flows).
  * Implemented pagination support for browsing collections with keyset cursor navigation.
  * Added formatted display of collection items with key details like dimensions, hotspots, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->