### PR TITLE
feat: self-heal Supabase publishable key on rotation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,10 +16,14 @@ export const COLOR_QUANTIZE_MAX = 248;
 
 /**
  * Public publishable key embedded in Mobbin's client JS. Required for Supabase auth API calls.
+ * Used as the initial seed only — at runtime the live value is owned by `AnonKeyManager`,
+ * which prefers a previously-discovered key from disk and self-heals via
+ * `discoverPublishableKey()` on a refresh-time `401 "Unregistered API key"`.
+ *
  * To find this yourself: open mobbin.com, DevTools → Network → filter for "supabase" →
  * check the `apikey` header on any request to ujasntkfphywizsdaapi.supabase.co.
  */
-export const SUPABASE_ANON_KEY = "sb_publishable_LbI2-4spKrYx1xHKrI4YyQ_rC-csyUz";
+export const SUPABASE_ANON_KEY = "sb_publishable_YptnKskI90SD2g25sAvVxQ_tZltjYFE";
 
 /**
  * Cookie name prefix used by Supabase for this project.

--- a/src/services/anon-key.ts
+++ b/src/services/anon-key.ts
@@ -1,0 +1,56 @@
+import { SUPABASE_ANON_KEY } from "../constants.js";
+import { readStoredAnonKey, writeStoredAnonKey } from "../utils/key-store.js";
+import { discoverPublishableKey } from "./key-discovery.js";
+
+/**
+ * Process-global holder for the Supabase publishable (anon) key.
+ *
+ * Mobbin rotates this key occasionally. We seed from {@link SUPABASE_ANON_KEY}
+ * (the value that was live when this build shipped), then prefer a previously
+ * discovered key from disk. On a refresh-time `401 "Unregistered API key"`,
+ * the auth layer calls {@link AnonKeyManager.rediscover} to scrape the
+ * current key from `https://mobbin.com/`'s `main-app-*.js` chunk.
+ *
+ * Concurrent rediscovery is deduplicated so a burst of failing tool calls
+ * triggers exactly one scrape.
+ */
+class AnonKeyManager {
+  private current: string;
+  private rediscoverPromise: Promise<string | null> | null = null;
+
+  constructor() {
+    this.current = readStoredAnonKey() ?? SUPABASE_ANON_KEY;
+  }
+
+  get(): string {
+    return this.current;
+  }
+
+  /**
+   * Scrape Mobbin for the current publishable key.
+   * Returns the new key if it differs from the current one and
+   * persists it to disk; returns `null` if discovery failed or
+   * found the same key we already have.
+   */
+  async rediscover(): Promise<string | null> {
+    if (this.rediscoverPromise) return this.rediscoverPromise;
+    this.rediscoverPromise = this.doRediscover().finally(() => {
+      this.rediscoverPromise = null;
+    });
+    return this.rediscoverPromise;
+  }
+
+  private async doRediscover(): Promise<string | null> {
+    const found = await discoverPublishableKey();
+    if (!found || found === this.current) return null;
+    this.current = found;
+    try {
+      writeStoredAnonKey(found);
+    } catch {
+      // Persistence is best-effort; in-memory value is still good for this process.
+    }
+    return found;
+  }
+}
+
+export const anonKey = new AnonKeyManager();

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,10 +1,10 @@
 import {
   SUPABASE_URL,
-  SUPABASE_ANON_KEY,
   SUPABASE_COOKIE_PREFIX,
   TOKEN_REFRESH_BUFFER_SECONDS,
   COOKIE_CHUNK_SIZE,
 } from "../constants.js";
+import { anonKey } from "./anon-key.js";
 
 export interface SupabaseSession {
   access_token: string;
@@ -96,23 +96,26 @@ export class MobbinAuth {
   }
 
   private async doRefresh(): Promise<void> {
-    const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=refresh_token`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        apikey: SUPABASE_ANON_KEY,
-      },
-      body: JSON.stringify({
-        refresh_token: this.session.refresh_token,
-      }),
-    });
+    let res = await this.callRefreshEndpoint(anonKey.get());
+
+    // Mobbin rotated their publishable key. Try to discover the new one and retry once.
+    if (res.status === 401) {
+      const body = await res.text().catch(() => "");
+      if (body.includes("Unregistered API key")) {
+        const recovered = await anonKey.rediscover();
+        if (recovered) {
+          res = await this.callRefreshEndpoint(recovered);
+        } else {
+          throw refreshFailureError(401, body);
+        }
+      } else {
+        throw refreshFailureError(401, body);
+      }
+    }
 
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      throw new Error(
-        `Token refresh failed (${res.status}): ${text.substring(0, 200)}. ` +
-          "Run 'npx mobbin-mcp auth' to re-authenticate.",
-      );
+      throw refreshFailureError(res.status, text);
     }
 
     const newSession = (await res.json()) as SupabaseSession;
@@ -122,6 +125,19 @@ export class MobbinAuth {
     if (this.onSessionRefreshed) {
       this.onSessionRefreshed(newSession);
     }
+  }
+
+  private async callRefreshEndpoint(apiKey: string): Promise<Response> {
+    return fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=refresh_token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: apiKey,
+      },
+      body: JSON.stringify({
+        refresh_token: this.session.refresh_token,
+      }),
+    });
   }
 
   /**
@@ -192,4 +208,11 @@ export class MobbinAuth {
     }
     return chunks.map((chunk, i) => `${SUPABASE_COOKIE_PREFIX}.${i}=${chunk}`).join("; ");
   }
+}
+
+function refreshFailureError(status: number, body: string): Error {
+  return new Error(
+    `Token refresh failed (${status}): ${body.substring(0, 200)}. ` +
+      "Run 'npx mobbin-mcp auth' to re-authenticate.",
+  );
 }

--- a/src/services/key-discovery.ts
+++ b/src/services/key-discovery.ts
@@ -1,0 +1,45 @@
+import { MOBBIN_BASE_URL } from "../constants.js";
+
+const MAIN_APP_CHUNK_RE = /\/_next\/static\/chunks\/main-app-[A-Za-z0-9_-]+\.js/g;
+const PUBLISHABLE_KEY_RE = /sb_publishable_[A-Za-z0-9_-]+/;
+
+export interface DiscoverOptions {
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}
+
+/**
+ * Scrape the current Supabase publishable key from Mobbin's web bundle.
+ *
+ * Mobbin embeds the literal `sb_publishable_*` key in the `main-app-*.js`
+ * chunk linked from the homepage HTML. We fetch the HTML, locate the chunk
+ * URL, fetch the chunk, and pluck the key with a regex.
+ *
+ * Returns `null` (never throws) on any failure — caller decides what to do.
+ * The whole operation shares one {@link AbortController} so the total budget
+ * is bounded by `timeoutMs` regardless of how many chunks are tried.
+ */
+export async function discoverPublishableKey(opts: DiscoverOptions = {}): Promise<string | null> {
+  const { timeoutMs = 10_000, fetchFn = fetch } = opts;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const homeRes = await fetchFn(`${MOBBIN_BASE_URL}/`, { signal: controller.signal });
+    if (!homeRes.ok) return null;
+    const html = await homeRes.text();
+
+    const chunkPaths = [...new Set([...html.matchAll(MAIN_APP_CHUNK_RE)].map((m) => m[0]))];
+    for (const path of chunkPaths) {
+      const chunkRes = await fetchFn(`${MOBBIN_BASE_URL}${path}`, { signal: controller.signal });
+      if (!chunkRes.ok) continue;
+      const chunkText = await chunkRes.text();
+      const match = chunkText.match(PUBLISHABLE_KEY_RE);
+      if (match) return match[0];
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/utils/key-store.ts
+++ b/src/utils/key-store.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { AUTH_DIR } from "./auth-store.js";
+
+const KEY_FILE = path.join(AUTH_DIR, "anon-key.json");
+
+interface StoredAnonKey {
+  key: string;
+  discoveredAt: number;
+}
+
+/**
+ * Read a previously-discovered Supabase publishable key from disk.
+ * Returns `null` if the file is missing, malformed, or contains a value
+ * that doesn't look like an `sb_publishable_*` key.
+ */
+export function readStoredAnonKey(): string | null {
+  try {
+    const data = JSON.parse(fs.readFileSync(KEY_FILE, "utf-8")) as Partial<StoredAnonKey>;
+    if (typeof data.key === "string" && data.key.startsWith("sb_publishable_")) {
+      return data.key;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a discovered key so subsequent process boots skip the scrape.
+ * Failures are silent — the in-memory key is still usable.
+ */
+export function writeStoredAnonKey(key: string): void {
+  fs.mkdirSync(AUTH_DIR, { recursive: true });
+  const tmp = KEY_FILE + ".tmp";
+  fs.writeFileSync(
+    tmp,
+    JSON.stringify({ key, discoveredAt: Date.now() } satisfies StoredAnonKey, null, 2),
+    { mode: 0o600 },
+  );
+  fs.renameSync(tmp, KEY_FILE);
+}


### PR DESCRIPTION
## Summary

When Mobbin rotates their public Supabase anon key, every tool call currently dies with `401 Unregistered API key` until someone bumps `SUPABASE_ANON_KEY` and ships a release. This PR makes the client recover on its own by scraping the live key from Mobbin's `main-app-*.js` chunk on that exact failure and retrying the refresh once.

Verified live: the key in `master`'s `constants.ts` (`sb_publishable_LbI2-...`) **does not match** the one Mobbin currently ships (`sb_publishable_Yptn...`). The local refresh on `master` is broken right now — this PR ships both the fix-now (bump the seed) and the never-again (self-heal).

## What changed

- `src/services/key-discovery.ts` — bounded scrape: `mobbin.com/` HTML → `main-app-*.js` chunk URL → regex out `sb_publishable_[A-Za-z0-9_-]+`. Single `AbortController` budget (10s default). Returns `null` (never throws) on any failure.
- `src/services/anon-key.ts` — process-global `AnonKeyManager` singleton. Seeds from `readStoredAnonKey() ?? SUPABASE_ANON_KEY`. `rediscover()` is deduped so a burst of concurrent 401s triggers exactly one scrape, persists the new key to disk, and returns `null` if discovery fails or returns the value we already have.
- `src/utils/key-store.ts` — `~/.mobbin-mcp/anon-key.json` (`0600`, atomic rename), mirroring the `auth-store.ts` convention.
- `src/services/auth.ts` — `doRefresh` reads from the holder. On `401` whose body contains `"Unregistered API key"` it calls `anonKey.rediscover()` and retries once with the recovered key. Any other 401 body, non-401 failure, or null discovery throws as before.
- `src/constants.ts` — bump the seed to the currently-live `sb_publishable_YptnKskI90SD2g25sAvVxQ_tZltjYFE` so fresh installs work without a discovery round-trip.

## Acceptance criteria (from #32)

- [x] On `401 "Unregistered API key"` from Supabase refresh, re-discover the key from `https://mobbin.com/` and retry once.
- [x] Discovery is bounded (single 10s budget across both fetches via shared `AbortController`).
- [x] Discovered key is cached at `~/.mobbin-mcp/anon-key.json` so cold starts after a real rotation skip the discovery hop.
- [ ] Fall through to the graceful path from #31 when discovery fails. **Caveat:** #31 is still draft, so that path doesn't exist on `master`. This PR throws on discovery failure, matching current master behavior. The throw site in `doRefresh` is the right spot to swap for the fallthrough once #31 lands — they compose cleanly.

## Test plan

Manual verification via `scripts/verify-self-heal.ts` (gitignored alongside the other probes). Two parts:

1. **Live discovery** — calls `discoverPublishableKey()` against the real `mobbin.com`, confirms it returns the current `sb_publishable_*` value.
2. **End-to-end self-heal** — mocks `globalThis.fetch` for the Supabase token endpoint to return `401 Unregistered API key` on the first call and `200 + valid session` on the second. Forces the holder to a stale value, then calls `MobbinAuth.getCookieValue()` against an expired session. Asserts:
   - Token endpoint hit twice
   - First call sent the stale key, second call sent the rediscovered key
   - In-memory session rotated to the new tokens
   - `onSessionRefreshed` callback fired
   - `anonKey.get()` reflects the rediscovered key
   - Cache file written with the new key

Result: 9/9 PASS against live Mobbin.

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx tsx scripts/verify-self-heal.ts`

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced authentication reliability with automatic key management and recovery. The app now intelligently handles authentication failures and can self-heal by discovering updated credentials when needed.

* **Bug Fixes**
  * Improved resilience during authentication refresh with fallback key discovery on credential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->