### PR TITLE
fix: accept trimmed row shape from element/keyword-filtered search-screens

### DIFF
--- a/src/services/schemas.ts
+++ b/src/services/schemas.ts
@@ -50,30 +50,51 @@ export const appResultSchema = z
   })
   .passthrough();
 
+/**
+ * Rows returned by `/api/content/search-screens`.
+ *
+ * Mobbin returns one of two shapes depending on the filter:
+ *   - **Full shape** (no filter, or filtered by `screenPatterns` / `appCategories`)
+ *     includes `screenNumber`, `screenKeywords`, `appCategory`, `allAppCategories`,
+ *     `appTagline`, `companyHqRegion`, `companyStage`, `popularityMetric`,
+ *     `trendingMetric`, and `metadata: { width, height }`.
+ *   - **Trimmed shape** (filtered by `screenElements` or `screenKeywords`)
+ *     omits all of the above and instead carries top-level `width`/`height`
+ *     plus `createdAt`.
+ *
+ * The optional fields below cover the trimmed shape; everything still required
+ * is present in both.
+ */
 export const screenResultSchema = z
   .object({
     type: z.string(),
     id: z.string(),
     screenUrl: z.string(),
     fullpageScreenUrl: z.string().nullable(),
-    screenNumber: z.number(),
     screenPatterns: z.array(z.string()),
     screenElements: z.array(z.string()),
-    screenKeywords: z.string(),
     appVersionId: z.string(),
     appId: z.string(),
     appName: z.string(),
-    appCategory: z.string(),
-    allAppCategories: z.array(z.string()),
     appLogoUrl: z.string(),
-    appTagline: z.string(),
-    companyHqRegion: z.string().nullable(),
-    companyStage: z.string().nullable(),
     platform: z.string(),
-    popularityMetric: z.number(),
-    trendingMetric: z.number(),
-    metadata: z.object({ width: z.number(), height: z.number() }).passthrough(),
     screenCdnImgSources: z.object({ src: z.string() }).passthrough().optional(),
+    // Full-shape-only fields — absent from element/keyword-filtered responses.
+    screenNumber: z.number().optional(),
+    screenKeywords: z.string().optional(),
+    appCategory: z.string().optional(),
+    allAppCategories: z.array(z.string()).optional(),
+    appTagline: z.string().optional(),
+    companyHqRegion: z.string().nullable().optional(),
+    companyStage: z.string().nullable().optional(),
+    popularityMetric: z.number().optional(),
+    trendingMetric: z.number().optional(),
+    metadata: z.object({ width: z.number(), height: z.number() }).passthrough().optional(),
+    // Trimmed-shape extras — top-level dimensions and timestamp Mobbin sends
+    // in lieu of `metadata`.
+    width: z.number().optional(),
+    height: z.number().optional(),
+    createdAt: z.string().optional(),
   })
   .passthrough();
 

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -38,21 +38,25 @@ export function formatApps(apps: AppResult[]): string {
 export function formatScreens(screens: ScreenResult[]): string {
   if (screens.length === 0) return "No screens found.";
 
-  const lines = screens.map((s, i) =>
-    [
+  const lines = screens.map((s, i) => {
+    // Element/keyword-filtered rows omit `metadata` and instead expose top-level
+    // `width`/`height`. Both shapes carry dimensions; pick whichever is present.
+    const width = s.metadata?.width ?? s.width;
+    const height = s.metadata?.height ?? s.height;
+    return [
       `### ${i + 1}. ${s.appName} — ${s.screenPatterns.join(", ") || "Screen"}`,
-      `- **App**: ${s.appName} (${s.appCategory})`,
+      `- **App**: ${s.appName}${s.appCategory ? ` (${s.appCategory})` : ""}`,
       `- **Platform**: ${s.platform}`,
       `- **Patterns**: ${s.screenPatterns.join(", ") || "None"}`,
       `- **Elements**: ${s.screenElements.join(", ") || "None"}`,
       `- **Screen URL**: ${s.screenUrl}`,
       `- **App ID**: ${s.appId}`,
       `- **Screen ID**: ${s.id}`,
-      s.metadata ? `- **Dimensions**: ${s.metadata.width}x${s.metadata.height}` : "",
+      width !== undefined && height !== undefined ? `- **Dimensions**: ${width}x${height}` : "",
     ]
       .filter(Boolean)
-      .join("\n"),
-  );
+      .join("\n");
+  });
 
   return truncate(lines.join("\n\n"));
 }


### PR DESCRIPTION
Closes #34
Closes #38

## Summary

- `mobbin_search_screens` was crashing on `screenElements`/`screenKeywords` filters because Mobbin's API returns a **trimmed row shape** for those filter types — omitting 10 fields (`screenNumber`, `screenKeywords`, `appCategory`, `allAppCategories`, `appTagline`, `companyHqRegion`, `companyStage`, `popularityMetric`, `trendingMetric`, `metadata`) and sending top-level `width`/`height`/`createdAt` instead.
- Schema is updated to describe both shapes precisely (only the genuinely-omitted fields are now `.optional()`; everything always present stays strict).
- `formatScreens` falls back to top-level `width`/`height` when `metadata` is absent and skips the parenthesized category when the trimmed shape omits `appCategory`.

The original bug reports (#34, #38) framed this as "older content with missing fields"; the actual cause is filter-dependent shape variance, confirmed by probing the live API across full-shape and trimmed-shape requests side by side. The omitted field set in #34 matches the trimmed shape exactly.

Regression source: #23 (boundary validation), where the schema was authored against the full shape and the trimmed-shape filter path wasn't covered.

## Test plan

Verified live against the Mobbin API:

- [x] Baseline probe — all 14 endpoints validate
- [x] Aggressive probe — element-filtered (`Button`), keyword-filtered (`login`), pattern-filtered (`Hero Section`), category-filtered (`Banking`), and deep-paginated (pageIndex 5/10/20/30) screen searches across iOS/Android/web all parse cleanly
- [x] `npm run build` (tsc), `npm run lint`, `npm run format:check` clean
- [x] End-to-end smoke: `searchScreens({ platform: "ios", screenKeywords: ["login"] })` → `formatScreens(...)` renders 5 rows with correct dimensions falling back to top-level `width`/`height`

🤖 Generated with [Claude Code](https://claude.com/claude-code)